### PR TITLE
added support for host key fingerprint verification

### DIFF
--- a/pyssh/__init__.py
+++ b/pyssh/__init__.py
@@ -8,7 +8,8 @@ from .sftp import Sftp
 
 
 def new_session(hostname="localhost", port="22", username=None,
-                password=None, passphrase=None, connect_on_init=False):
+                password=None, passphrase=None, connect_on_init=False,
+                verify_knownhost_callback=None):
     """
     Shortcut method for create new session instance.
 
@@ -27,7 +28,8 @@ def new_session(hostname="localhost", port="22", username=None,
     """
 
     session = Session(hostname=hostname, port=port, username=username,
-                      password=password, passphrase=passphrase)
+                      password=password, passphrase=passphrase,
+                      verify_knownhost_callback=verify_knownhost_callback)
     if connect_on_init:
         session._connect_if_not_connected()
     return session

--- a/pyssh/api.py
+++ b/pyssh/api.py
@@ -113,6 +113,12 @@ try:
     library.ssh_get_error.argtypes = [ctypes.c_void_p]
     library.ssh_get_error.restype = ctypes.c_char_p
 
+    library.ssh_get_pubkey_hash.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_char_p)]
+    library.ssh_get_pubkey_hash.restype = ctypes.c_int
+
+    library.ssh_clean_pubkey_hash.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
+    library.ssh_clean_pubkey_hash.restype = None
+
     # SFTP
     library.sftp_new.argtypes = [ctypes.c_void_p]
     library.sftp_new.restype = ctypes.c_void_p

--- a/pyssh/exceptions.py
+++ b/pyssh/exceptions.py
@@ -18,3 +18,7 @@ class ConnectionError(SshError):
 
 class ResourceManagementError(SshError):
     pass
+
+
+class HostVerificationError(SshError):
+    pass


### PR DESCRIPTION
I have added support for host fingerprint verification as SSH without it is insecure. The changes shouldn't break anything on existing code - that said, it is a very bad idea to connect to hosts without verifying them. 

This feature relies on user performing the necessary validation (comparing the supplied value to values in DB or elsewhere). Libssh also provides a set of functions which allow saving known hosts to ~/.ssh/known_hosts file, however, this patch does NOT implement interface to them. 

Btw, I have zero experience in contributing to such projects... Let me know if anything should be done differently. :)
